### PR TITLE
Refs #7 - Add support for coveralls.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,8 +1,11 @@
 language: node_js
 sudo: false
 node_js:
-  - "0.10"
+- '0.10'
+env:
+  global:
+    secure: LE0ESSk4xUUZUJafYGYm2jT+OEoXZciqZmLNmSHyx6l0SSMn/gwIayz3YLQ05MBg4X74m6FOU8niTa8b3KhGDk/jOXAU2tkGtfUsbxPqjK/DwH7nY5+kWGHFkmJgltjXAyIZUCYYbIeEmpCV0HEHEHjoIHxmrgL2lHGfhEiyhvg=
 before_install:
-  - export CHROME_BIN=chromium-browser
-  - export DISPLAY=:99.0
-  - sh -e /etc/init.d/xvfb start
+- export CHROME_BIN=chromium-browser
+- export DISPLAY=:99.0
+- sh -e /etc/init.d/xvfb start

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 Readinglist client
 ==================
 
-[![Build Status](https://travis-ci.org/n1k0/readinglist-client.svg?branch=master)](https://travis-ci.org/n1k0/readinglist-client) [![Dependency Status](https://www.versioneye.com/user/projects/54c76b2d1a0071823a000580/badge.svg?style=flat)](https://www.versioneye.com/user/projects/54c76b2d1a0071823a000580)
+[![Build Status](https://travis-ci.org/n1k0/readinglist-client.svg?branch=master)](https://travis-ci.org/n1k0/readinglist-client) [![Dependency Status](https://www.versioneye.com/user/projects/54c76b2d1a0071823a000580/badge.svg?style=flat)](https://www.versioneye.com/user/projects/54c76b2d1a0071823a000580) [![Coverage Status](https://coveralls.io/repos/n1k0/readinglist-client/badge.svg)](https://coveralls.io/r/n1k0/readinglist-client)
 
 This is work in progress at a temporary location.
 

--- a/karma.conf.js
+++ b/karma.conf.js
@@ -46,13 +46,14 @@ module.exports = function(config) {
         { type: "html", subdir: "report-html" },
         { type: "text", subdir: ".", file: "complete.txt" },
         { type: "text-summary", subdir: ".", file: "simple.txt" },
+        { type: "lcov", subdir: "." }
       ]
     },
 
     // test results reporter to use
     // possible values: "dots", "progress"
     // available reporters: https://npmjs.org/browse/keyword/karma-reporter
-    reporters: ["progress", "coverage"],
+    reporters: ["progress", "coverage", "coveralls"],
 
     // web server port
     port: 9876,

--- a/package.json
+++ b/package.json
@@ -45,6 +45,7 @@
     "karma-chai": "^0.1.*",
     "karma-chrome-launcher": "^0.1.7",
     "karma-coverage": "^0.2.7",
+    "karma-coveralls": "^0.1.5",
     "karma-firefox-launcher": "^0.1.*",
     "karma-mocha": "^0.1.*",
     "karma-react-preprocessor": "0.0.*",


### PR DESCRIPTION
Let's see how it goes.

> Be patiant when sending coverage information to coveralls, it can take upto 4 hours for things to start showing up properly.
> — https://github.com/caitp/karma-coveralls

Badge to enjoy the result eventually: [![Coverage Status](https://coveralls.io/repos/n1k0/readinglist-client/badge.svg)](https://coveralls.io/r/n1k0/readinglist-client)
