### PR TITLE
Optimized vendor build.

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -49,7 +49,22 @@ var opt = {
     src: "./src/js/main.js",
     dest: "bundle.js"
   },
-  vendors: "vendors.js",
+  vendors: {
+    target: "vendors.js",
+    modules: [
+      "babel/polyfill",
+      "docbrown",
+      "react/addons",
+      "rest",
+      "rest",
+      "rest/interceptor/pathPrefix",
+      "rest/interceptor/mime",
+      "rest/interceptor/errorCode",
+      "rest/interceptor/defaultRequest",
+      "rest/interceptor/hateoas",
+      "rest/interceptor"
+    ]
+  },
   karmaConfigPath: path.join(__dirname, "karma.conf.js")
 };
 
@@ -88,23 +103,21 @@ gulp.task("assets:fonts", function() {
  */
 gulp.task("js", ["js:vendors", "js:app"]);
 
+gulp.task("js:vendors", function() {
+  return browserify()
+    .require(opt.vendors.modules)
+    .bundle()
+    .pipe(source(opt.vendors.target))
+    .pipe(gulp.dest(opt.outputFolder + "/js"));
+});
+
 gulp.task("js:app", ["js:vendors"], function() {
   return browserify(opt.app.src)
-    .external("react/addons")
-    .external("docbrown")
+    .external(opt.vendors.modules)
     .transform(babelify)
     .transform(envify(opt.envifyVars))
     .bundle()
     .pipe(source(opt.app.dest))
-    .pipe(gulp.dest(opt.outputFolder + "/js"));
-});
-
-gulp.task("js:vendors", function() {
-  return browserify()
-    .require("react/addons")
-    .require("docbrown")
-    .bundle()
-    .pipe(source(opt.vendors))
     .pipe(gulp.dest(opt.outputFolder + "/js"));
 });
 
@@ -146,8 +159,7 @@ gulp.task("tdd", function(done) {
  */
 gulp.task("watchify", function() {
   var b = browserify(opt.app.src, watchify.args)
-    .external("react/addons")
-    .external("docbrown")
+    .external(opt.vendors.modules)
     .transform(babelify)
     .transform(envify(opt.envifyVars));
 

--- a/src/js/components/App.js
+++ b/src/js/components/App.js
@@ -1,8 +1,5 @@
 "use strict";
 
-// Load 6to5 polyfills http://6to5.org/docs/usage/polyfill/
-import "babel/polyfill";
-
 import React from "react/addons";
 import DocBrown from "docbrown";
 import { ArticleActions, stores } from "../flux";

--- a/src/test/index.js
+++ b/src/test/index.js
@@ -1,5 +1,6 @@
 "use strict";
 
+import "babel/polyfill";
 import "./api_test";
 import "./components";
 import "./content_test";


### PR DESCRIPTION
Too many external vendor libs are currently bundled in the application bundle, which makes watching for app js asset changes longer than what could be. This patch fixes that situation.

Current master:

```
 niko@n1k0-moz ~/Sites/readinglist-client (master)
$ gulp dist
[…]
 niko@n1k0-moz ~/Sites/readinglist-client (master)
$ ll build/js
total 592
drwxr-xr-x  4 niko  staff     136 Mar  1 10:24 .
drwxr-xr-x  7 niko  staff     238 Mar  1 10:24 ..
-rw-r--r--  1 niko  staff  107891 Mar  1 10:24 bundle.js
-rw-r--r--  1 niko  staff  191367 Mar  1 10:24 vendors.js
```

With the patch applied:

```
 niko@n1k0-moz ~/Sites/readinglist-client (optimized-vendor-build)
$ gulp dist
[…]
 niko@n1k0-moz ~/Sites/readinglist-client (optimized-vendor-build)
$ ll build/js
total 592
drwxr-xr-x  4 niko  staff     136 Mar  1 10:25 .
drwxr-xr-x  7 niko  staff     238 Mar  1 10:25 ..
-rw-r--r--  1 niko  staff   30613 Mar  1 10:25 bundle.js
-rw-r--r--  1 niko  staff  269222 Mar  1 10:25 vendors.js
```
